### PR TITLE
infra: remove react-h5-audio-player dependency

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,8 +11,7 @@
         "howler": "^2.2.4",
         "js-cookie": "^3.0.5",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1",
-        "react-h5-audio-player": "^3.9.3"
+        "react-dom": "^18.3.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
@@ -263,18 +262,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
-      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
-      "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -965,27 +952,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
-    },
-    "node_modules/@iconify/react": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@iconify/react/-/react-4.1.1.tgz",
-      "integrity": "sha512-jed14EjvKjee8mc0eoscGxlg7mSQRkwQG3iX3cPBCO7UlOjz0DtlvTqxqEcHUJGh+z1VJ31Yhu5B9PxfO0zbdg==",
-      "license": "MIT",
-      "dependencies": {
-        "@iconify/types": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/cyberalien"
-      },
-      "peerDependencies": {
-        "react": ">=16"
-      }
-    },
-    "node_modules/@iconify/types": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
-      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
-      "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.8",
@@ -3738,20 +3704,6 @@
         "react": "^18.3.1"
       }
     },
-    "node_modules/react-h5-audio-player": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/react-h5-audio-player/-/react-h5-audio-player-3.9.3.tgz",
-      "integrity": "sha512-D92SbCk6AJAsXYQ2qJqxeAvEjRXBQHY2q6dIZLaLL74eZi7VfynC0/EspHHbFDqBXDq7o2xNFH1Vas+HyXeE/w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.2",
-        "@iconify/react": "^4.1.1"
-      },
-      "peerDependencies": {
-        "react": "^16.3.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.3.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -3791,12 +3743,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,8 +13,7 @@
     "howler": "^2.2.4",
     "js-cookie": "^3.0.5",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "react-h5-audio-player": "^3.9.3"
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",


### PR DESCRIPTION
Removed the react-h5-audio-player dependency from the project.
The application will move towards a fully custom audio player built on top of the HTML5 Audio API with a custom UI layer.

**Technical Notes**

Audio playback will later be implemented via HTMLAudioElement and useRef
UI will be implemented using Radix UI primitives and Tailwind styles
[RW-6](https://linear.app/radio-web-app/issue/RW-6)
