### PR TITLE
Verify radio playback behaviour after refactor

### DIFF
--- a/frontend/src/Radio.tsx
+++ b/frontend/src/Radio.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useOutletContext } from "react-router-dom";
 import defaultImage from "./radio.avif";
 import { StationCard } from "./components/organisms/StationCard";
+import type { PlayerStatus } from "./lib/player/radioPlayer.types";
 
 type Station = {
   stationuuid: string;
@@ -20,6 +21,7 @@ type RadioLayoutContext = {
 type PlayerOutletContext = {
   player: {
     currentSrc: string | null;
+    status: PlayerStatus;
     toggle: (src: string) => void;
   };
 };
@@ -50,6 +52,12 @@ export default function Radio() {
       setCurrentPage(1);
     });
   }, [stationFilter, selectedCountry, setCountries]);
+
+  useEffect(() => {
+    if (player.status === "error") {
+      alert("Станция недоступна");
+    }
+  }, [player.status]);
 
   async function setupApi(filter: string, country: string): Promise<Station[]> {
     try {

--- a/frontend/src/lib/player/useRadioPlayer.ts
+++ b/frontend/src/lib/player/useRadioPlayer.ts
@@ -11,7 +11,12 @@ export function useRadioPlayer() {
   //states for UI
   const [currentSrc, setCurrentSrc] = useState<string | null>(null);
   const [status, setStatus] = useState<PlayerStatus>("idle");
-  const [volume, setVolume] = useState(1);
+  const [volume, setVolumeState] = useState(1);
+
+  const setVolume = useCallback((v: number) => {
+    setVolumeState(v);
+    soundRef.current?.volume(v);
+  }, []);
 
   const play = useCallback(
     (src: string) => {


### PR DESCRIPTION
1. setStatus("error") was silent. Restored the alert via useEffect watching player.status.
2. setVolume was the raw React setter — it never called soundRef.current?.volume(v).  Wrapped it to update the active Howl instance immediately

[RW-70](https://linear.app/radio-web-app/issue/RW-70/verify-radio-playback-behaviour-after-refactor)